### PR TITLE
Added troubleshooting info for Rook and Ceph

### DIFF
--- a/assets/application-configs/rook/clusters/sda4.yaml
+++ b/assets/application-configs/rook/clusters/sda4.yaml
@@ -3,10 +3,10 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: ceph-cluster
-  namespace: rook-system
+  namespace: rook-ceph
 spec:
   cephVersion:
-    image: olcne/ceph:v17.2.5
+    image: olcne/ceph:${CEPH_IMAGE_TAG}
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -27,7 +27,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: replicapool
-  namespace: rook-system
+  namespace: rook-ceph
 spec:
   failureDomain: host
   replicated:
@@ -37,12 +37,12 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: rook-ceph-block
-  namespace: rook-system
+  namespace: rook-ceph
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-provisioner: rook-system.rbd.csi.ceph.com
+provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
-  clusterID: rook-system # namespace:cluster
+  clusterID: rook-ceph # namespace:cluster
  
   pool: replicapool
   imageFormat: "2"
@@ -51,11 +51,11 @@ parameters:
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-  csi.storage.k8s.io/provisioner-secret-namespace: rook-system # namespace:cluster
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
   csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-  csi.storage.k8s.io/controller-expand-secret-namespace: rook-system # namespace:cluster
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
   csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-  csi.storage.k8s.io/node-stage-secret-namespace: rook-system # namespace:cluster
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
   csi.storage.k8s.io/fstype: ext4
 allowVolumeExpansion: true
 reclaimPolicy: Delete

--- a/assets/application-configs/rook/troubleshooting/toolbox-job.yaml
+++ b/assets/application-configs/rook/troubleshooting/toolbox-job.yaml
@@ -1,0 +1,62 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rook-ceph-toolbox-job
+  namespace: rook-ceph # namespace:cluster
+  labels:
+    app: ceph-toolbox-job
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: config-init
+          image: olcne/ceph:${ROOK_IMAGE_TAG}
+          command: ["/usr/local/bin/toolbox.sh"]
+          args: ["--skip-watch"]
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+            - name: ceph-admin-secret
+              mountPath: /var/lib/rook-ceph-mon
+      containers:
+        - name: script
+          image: olcne/ceph:${ROOK_IMAGE_TAG}
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+              readOnly: true
+          command:
+            - "bash"
+            - "-c"
+            - |
+              # Modify this script to run any ceph, rbd, radosgw-admin, or other commands that could
+              # be run in the toolbox pod. The output of the commands can be seen by getting the pod log.
+              #
+              # example: print the ceph status
+              ${ROOK_CEPH_COMMAND}
+      volumes:
+        - name: ceph-admin-secret
+          secret:
+            secretName: rook-ceph-mon
+            optional: false
+            items:
+              - key: ceph-secret
+                path: secret.keyring
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+              - key: data
+                path: mon-endpoints
+        - name: ceph-config
+          emptyDir: {}
+      restartPolicy: Never

--- a/examples/rook/simple.md
+++ b/examples/rook/simple.md
@@ -34,16 +34,29 @@ sda      8:0    0  256G  0 disk
 `-sda4   8:4    0  226G  0 part 
 ```
 
+Listing the available rook versions in the OCNE catalog
+```
+$ ocne catalog search --pattern rook
+APPLICATION	VERSION
+rook       	1.12.3
+```
+
 Now install Rook.
 
+Installing the latest version of rook available in the ocne catalog
 ```
-$ ocne application install --namespace rook-system --name rook --release rook --values https://raw.githubusercontent.com/oracle-cne/memoirs/refs/heads/main/assets/application-configs/rook/simple/values.yaml
+$ ocne application install --namespace rook-ceph --name rook --release rook --values https://raw.githubusercontent.com/oracle-cne/memoirs/refs/heads/main/assets/application-configs/rook/simple/values.yaml
+```
+OR
+Installing a specific version of rook available in the ocne catalog. Example installing rook 1.12.3 below:
+```
+$ ocne application install --namespace rook-ceph --name rook --release rook --version 1.12.3 --values https://raw.githubusercontent.com/oracle-cne/memoirs/refs/heads/main/assets/application-configs/rook/simple/values.yaml
 ```
 
 Now wait for Rook to become available.
 ```
-$ kubectl -n rook-system rollout status deployment rook-ceph-operator -w
-$ kubectl -n rook-system get pod -l app=rook-ceph-operator
+$ kubectl -n rook-ceph rollout status deployment rook-ceph-operator -w
+$ kubectl -n rook-ceph get pod -l app=rook-ceph-operator
 NAME                                  READY   STATUS    RESTARTS   AGE
 rook-ceph-operator-548dd6b98f-2nqfp   1/1     Running   0          3m
 ```
@@ -52,17 +65,22 @@ rook-ceph-operator-548dd6b98f-2nqfp   1/1     Running   0          3m
 
 Now that Ceph is available, create a Ceph cluster that targets `/dev/sda4`
 
+Note: Set CEPH_IMAGE_TAG environment variable according to the rook version already installed.
+|Rook version     |CEPH_IMAGE_TAG    |
+|-----------------|------------------|
+|1.12.3           |v17.2.5           |
 ```
-$ kubectl apply -f https://raw.githubusercontent.com/oracle-cne/memoirs/refs/heads/main/assets/application-configs/rook/clusters/sda4.yaml
+$ export CEPH_IMAGE_TAG="v17.2.5"
+$ envsubst < https://raw.githubusercontent.com/oracle-cne/memoirs/refs/heads/main/assets/application-configs/rook/clusters/sda4.yaml | kubectl apply -f -
 ```
 
 After applying these resources, Rook will begin configuring and creating a
 Ceph cluster.  This can take a while to finish.  Many deployments and daemonsets
 are installed, and there are some jobs that have non-trivial runtimes.
-Eventually, the `rook-system` namespace will look something like this:
+Eventually, the `rook-ceph` namespace will look something like this:
 
 ```
-$ kubectl get pods -n rook-system
+$ kubectl get pods -n rook-ceph
 NAME                                                         READY   STATUS      RESTARTS   AGE
 csi-cephfsplugin-2rqxn                                       2/2     Running     0          3h3m
 csi-cephfsplugin-988k8                                       2/2     Running     0          3h3m
@@ -118,6 +136,43 @@ my-pvc   Bound    pvc-a8295ccc-ff25-4466-94d5-8a37ec84f346   5Gi        RWO     
 $ kubectl get persistentvolumes
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM            STORAGECLASS      VOLUMEATTRIBUTESCLASS   REASON   AGE
 pvc-a8295ccc-ff25-4466-94d5-8a37ec84f346   5Gi        RWO            Delete           Bound    default/my-pvc   rook-ceph-block   <unset>                          3m52s
+```
+
+# Troubleshooting
+Note: Set ROOK_IMAGE_TAG environment variable according to the rook version already installed.
+|Rook version     |ROOK_IMAGE_TAG    |
+|-----------------|------------------|
+|1.12.3           |v1.12.3           |
+
+Note: Set ROOK_CEPH_COMMAND environment variable to run any ceph, rbd, radosgw-admin, or other commands that could be run in the toolbox pod.
+Sample example commands below:
+```
+ceph status
+ceph osd status
+ceph osd df
+ceph osd utilization
+ceph osd pool stats
+ceph osd tree
+ceph pg stat
+rados df
+```
+Refer Rook and Ceph documentation for an exhaustive list of commands. Few links for reference below:
+- [Rook Troubleshooting](https://rook.io/docs/rook/latest-release/Troubleshooting)
+- [Ceph Object Gateway / radosgw-admin -- rados REST gateway user administration utility](https://docs.ceph.com/en/reef/man/8/radosgw-admin/)
+- [Ceph Storage Cluster / Object Store Manpages](https://docs.ceph.com/en/latest/rados/man/)
+
+```
+$ export ROOK_IMAGE_TAG="v1.12.3"
+$ export ROOK_CEPH_COMMAND="ceph status"
+$ envsubst < https://raw.githubusercontent.com/oracle-cne/memoirs/refs/heads/main/assets/application-configs/rook/troubleshooting/toolbox-job.yaml | kubectl apply -f -
+```
+After the above toolbox job completes, see the results of the script:
+```
+$ kubectl -n rook-ceph logs -l job-name=rook-ceph-toolbox-job
+```
+Please make sure to delete the toolbox job before proceeding to execute the toolbox job with a different command:
+```
+$ kubectl -n rook-ceph delete jobs.batch rook-ceph-toolbox-job
 ```
 
 # Cleanup


### PR DESCRIPTION
Added troubleshooting info for Rook and Ceph.

Note: The namespace has been intentionally been changed from `rook-system` to `rook-ceph` to maintain consistency with upstream Rook and Ceph documentation.
